### PR TITLE
chore: migrate to jerus-org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,3 +95,4 @@ workflows:
           context:
             - release
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
+          min_rust_version: << pipeline.parameters.min-rust-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,10 @@ workflows:
       - required-builds
       - docs
       - optional-builds
-      - toolkit/common_tests
-      - toolkit/idiomatic_rust
+      - toolkit/common_tests:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+      - toolkit/idiomatic_rust:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
       - toolkit/update_changelog:
           requires:
             - required-builds
@@ -81,6 +83,7 @@ workflows:
           context:
             - release
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
+          min_rust_version: << pipeline.parameters.min-rust-version >>
 
   release:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
 
 orbs:
-  toolkit: jerusdp/circleci-toolkit@0.20.0
+  toolkit: jerus-org/circleci-toolkit@0.20.0
 
 executors:
   rust-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
 
 orbs:
-  toolkit: jerusdp/circleci-toolkit@0.9.4
+  toolkit: jerusdp/circleci-toolkit@0.20.0
 
 executors:
   rust-env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate to circleci
 - Enable missing doc check feature on nightly
 - Minrust and typo
+- chore-migrate to jerus-org(pr [#40])
 
 ### Security
 
@@ -54,9 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Convert batch of messages to vec of user provider struct
 
 [#39]: https://github.com/jerusdp/lambda_sqs/pull/39
-[Unreleased]: https://github.com/jerusdp/lambda_sqs/compare/0.2.4...HEAD
-[0.2.4]: https://github.com/jerusdp/lambda_sqs/compare/0.2.3...0.2.4
-[0.2.3]: https://github.com/jerusdp/lambda_sqs/compare/0.2.2...0.2.3
-[0.2.2]: https://github.com/jerusdp/lambda_sqs/compare/0.2.1...0.2.2
-[0.2.1]: https://github.com/jerusdp/lambda_sqs/compare/0.2.0...0.2.1
-[0.2.0]: https://github.com/jerusdp/lambda_sqs/releases/tag/0.2.0
+[#40]: https://github.com/jerus-org/lambda_sqs/pull/40
+[Unreleased]: https://github.com/jerus-org/lambda_sqs/compare/0.2.4...HEAD
+[0.2.4]: https://github.com/jerus-org/lambda_sqs/compare/0.2.3...0.2.4
+[0.2.3]: https://github.com/jerus-org/lambda_sqs/compare/0.2.2...0.2.3
+[0.2.2]: https://github.com/jerus-org/lambda_sqs/compare/0.2.1...0.2.2
+[0.2.1]: https://github.com/jerus-org/lambda_sqs/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/jerus-org/lambda_sqs/releases/tag/0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.2.4"
 description = """
 Handles an SQS event and provides a vec of your type for processing. 
 """
-edition = "2018"
+edition = "2021"
 authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/jerusdp/lambda_sqs"
+repository = "https://github.com/jerus-org/lambda_sqs"
 readme = "README.md"
 documentation = "https://docs.rs/lambda-sqs"
 categories = ["web-programming"]

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ dual licensed as above, without any additional terms or conditions.
 [crates-url]: https://crates.io/crates/lambda_sqs
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: https://github.com/jerusdp/lambda_sqs/blob/main/LICENSE
-[circleci-badge]: https://dl.circleci.com/status-badge/img/gh/jerusdp/lambda_sqs/tree/main.svg?style=svg
-[circleci-url]: https://dl.circleci.com/status-badge/redirect/gh/jerusdp/lambda_sqs/tree/main
+[circleci-badge]: https://dl.circleci.com/status-badge/img/gh/jerus-org/lambda_sqs/tree/main.svg?style=svg
+[circleci-url]: https://dl.circleci.com/status-badge/redirect/gh/jerus-org/lambda_sqs/tree/main
 [version-badge]: https://img.shields.io/badge/rust-1.65+-orange.svg
 [version-url]: https://www.rust-lang.org
 [fossa-badge]: https://app.fossa.com/api/projects/custom%2B22707%2Fgit%40github.com%3Ajerusdp%2Flambda_sqs.git.svg?type=shield


### PR DESCRIPTION
* chore(circleci/config.yml): update toolkit version from 0.9.4 to 0.20.0
* feat(Cargo.toml): update edition from 2018 to 2021 and change repository url
* docs(README.md): update circleci badge and url to reflect new repository url