### PR TITLE
👷 ci(circleci): update CI workflow with version management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,10 +96,31 @@ workflows:
         - not: << pipeline.parameters.success-flag >>
         - not: << pipeline.parameters.validation-flag >>
     jobs:
+      - toolkit/save_next_version:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+
       - toolkit/make_release:
           context:
             - release
             - bot-check
+          requires:
+            - toolkit/save_next_version
+          pre-steps:
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                name: Set SEMVER based on next-version file
+                command: |
+                  set +ex
+                  export SEMVER=$(cat /tmp/workspace/next-version)
+                  echo $SEMVER
+                  echo "export SEMVER=$SEMVER" >> "$BASH_ENV"
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           when_use_workspace: false
+
+      - toolkit/no_release:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          requires:
+            - toolkit/save_next_version
+              - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ci(circleci)-update configuration with new parameter(pr [#75])
 - chore(config)-migrate renovate config(pr [#78])
+- 👷 ci(circleci): update CI workflow with version management(pr [#79])
 
 ### Security
 
@@ -224,6 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#76]: https://github.com/jerus-org/lambda_sqs/pull/76
 [#77]: https://github.com/jerus-org/lambda_sqs/pull/77
 [#78]: https://github.com/jerus-org/lambda_sqs/pull/78
+[#79]: https://github.com/jerus-org/lambda_sqs/pull/79
 [Unreleased]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.20...HEAD
 [0.2.20]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.18...v0.2.19


### PR DESCRIPTION
- add job for saving the next version before release
- set SEMVER environment variable based on the next-version file
- ensure toolkit/no_release job depends on successful next version save