### PR TITLE
👷 ci(circleci): fix incorrect workflow indentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,5 +122,5 @@ workflows:
       - toolkit/no_release:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           requires:
-            - toolkit/save_next_version
-              - failed
+            - toolkit/save_next_version:
+                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ci(circleci)-update configuration with new parameter(pr [#75])
 - chore(config)-migrate renovate config(pr [#78])
 - 👷 ci(circleci): update CI workflow with version management(pr [#79])
+- 👷 ci(circleci): fix incorrect workflow indentation(pr [#80])
 
 ### Security
 
@@ -226,6 +227,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#77]: https://github.com/jerus-org/lambda_sqs/pull/77
 [#78]: https://github.com/jerus-org/lambda_sqs/pull/78
 [#79]: https://github.com/jerus-org/lambda_sqs/pull/79
+[#80]: https://github.com/jerus-org/lambda_sqs/pull/80
 [Unreleased]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.20...HEAD
 [0.2.20]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.18...v0.2.19


### PR DESCRIPTION
- adjust indentation of the 'failed' condition under 'requires' for proper YAML syntax