### PR TITLE
chore: update release.toml to reference PRLOG.md instead of CHANGELOG.md

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#110])
+- chore-update release.toml to reference PRLOG.md instead of CHANGELOG.md(pr [#111])
 
 ### Security
 
@@ -368,6 +369,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#108]: https://github.com/jerus-org/lambda_sqs/pull/108
 [#109]: https://github.com/jerus-org/lambda_sqs/pull/109
 [#110]: https://github.com/jerus-org/lambda_sqs/pull/110
+[#111]: https://github.com/jerus-org/lambda_sqs/pull/111
 [Unreleased]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.34...HEAD
 [0.2.34]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.33...v0.2.34
 [0.2.33]: https://github.com/jerus-org/lambda_sqs/compare/v0.2.32...v0.2.33

--- a/release.toml
+++ b/release.toml
@@ -2,7 +2,7 @@
 pre-release-replacements = [
     { file = "README.md", search = "lambda_sqs = .*", replace = "{{crate_name}} = \" {{version}}\"" },
     { file = "src/lib.rs", search = "lambda_sqs = .*", replace = "{{crate_name}} = \" {{{version}}\"" },
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]


### PR DESCRIPTION
This PR updates the `release.toml` configuration file to reference `PRLOG.md` instead of `CHANGELOG.md`.

## Changes
- Updated all file references from `CHANGELOG.md` to `PRLOG.md` in `release.toml`
- No functional changes to the release process, only file name consistency

## Context
This change aligns with the recent standardization effort to use `PRLOG.md` (Pull Request Log) as the consistent naming convention for changelog files across all repositories. The release automation tooling now properly references the renamed changelog file.

## Files Modified
- `release.toml` - Updated file references in release configuration