### PR TITLE
fix: remove jq from tools verification

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -24,7 +24,6 @@ jobs:
             nextsv --version
             pcu --version
             cargo release --version
-            jq --version
 
 workflows:
   release:


### PR DESCRIPTION
## Summary

- Remove `jq --version` from the `tools` verification step in `release.yml`
- `jq` is not installed in the `rust_env_rolling` executor and is not used anywhere in the release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)