### PR TITLE
ci: run sonarcloud security on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ workflows:
           filters:
             branches:
               only:
-                - main
                 - /pull\/[0-9]+/
       - toolkit/security:
           name: security with sonarcloud
@@ -60,7 +59,6 @@ workflows:
             branches:
               ignore:
                 - /pull\/[0-9]+/
-                - main
       - toolkit/code_coverage:
           package: lambda_sqs
           filters:


### PR DESCRIPTION
## Problem

The `security with sonarcloud` job **ignored `main`** (and `security audit only` ran *on* main), so SonarCloud never scanned `main`. GitHub then flags main's code-scanning results as **"may be out of date"** — even though the same code passed scanning as a PR (PR-ref scans don't satisfy the `main` branch).

## Fix

Move `main` out of both filters, matching the known-good shape (kdeets):
- `security audit only` → `only: /pull\/[0-9]+/` (forked PRs only — SonarCloud secrets/context aren't available there)
- `security with sonarcloud` → `ignore: /pull\/[0-9]+/` (everything else, **including main** + non-forked PRs)

So `main` is scanned + uploaded on every push, keeping code-scanning/SonarCloud results current.

CI-config-only change.
