### PR TITLE
chore: remove redundant toolkit/label job

### DIFF
--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -22,7 +22,3 @@ workflows:
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
-      - toolkit/label:
-          context: pcu-app
-          requires:
-            - update-prlog-on-main


### PR DESCRIPTION
`toolkit/update_prlog` labels the oldest open Renovate PR by default (`run_label: true`), so the standalone `toolkit/label` job that ran after `update-prlog-on-main` double-labels the queue. Removing it — labeling continues via the built-in step in `update_prlog`.

Matches the already-migrated repos (pcu, zola-orb, zola-container, circleci-toolkit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)